### PR TITLE
Mute: use toggle instead of absolute values

### DIFF
--- a/pa-vol.sh
+++ b/pa-vol.sh
@@ -36,11 +36,7 @@ function minus() {
 }
  
 function mute() {
-        if [ $MUTE_STATE = no ]; then
-                pactl set-sink-mute $SINK_NAME 1
-        elif [ $MUTE_STATE = yes ]; then
-                pactl set-sink-mute $SINK_NAME 0
-        fi
+        pactl set-sink-mute $SINK_NAME toggle
 }
  
 function get() {


### PR DESCRIPTION
There is no need to get and give absolute valuesas we can use toggle.
